### PR TITLE
Check version of cryptography module

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.xbmc.versioncheck"
        name="Version Check"
-      version="0.3.28"
+      version="0.4.0"
       provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -111,3 +111,17 @@ msgstr ""
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr ""
+
+#empty strings from id 32036 to 32039
+
+msgctxt "#32040"
+msgid "Your version %s of the Python cryptography module is too old. You need at least version 1.7."
+msgstr ""
+
+msgctxt "#32041"
+msgid "Please upgrade your operating system."
+msgstr ""
+
+msgctxt "#32042"
+msgid "For more information, see https://kodi.wiki/view/Linux"
+msgstr ""


### PR DESCRIPTION
We have had multiple issues with Ubuntu 16.04 using an outdated version
of the Python cryptography module that causes strange SSL behavior.
Example for this is not being able to connect to SSL sites.

This commit introduces a check on Kodi startup so the user is aware
of the issue.

See also:
https://github.com/pyca/pyopenssl/issues/542#issuecomment-312968275
https://forum.kodi.tv/showthread.php?tid=335786

xbmc/xbmc#14512