### PR TITLE
Compatibility layer for gotham

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-XBMC Versioncheck
+Kodi Version Check service addon
 =========================
 
-This service checks the installed XBMC version against the next available one and notifies you if there is a new version available.
+This service checks the installed Kodi/XBMC version against the next available one and notifies you if there is a new version available.
 When a new version comes out the versions.txt should be updated to reflect the latest version available.
 When updating the version.txt always put latest release at the top since the list is read in chronological order.

--- a/lib/common.py
+++ b/lib/common.py
@@ -33,6 +33,7 @@ else:
     ADDONPATH    = ADDON.getAddonInfo('path').decode('utf-8')
     ADDONPROFILE = xbmc.translatePath( ADDON.getAddonInfo('profile') ).decode('utf-8')
 ICON         = ADDON.getAddonInfo('icon')
+KODI_VERSION_MAJOR = int(xbmc.getInfoLabel('System.BuildVersion')[0:2])
 
 monitor = xbmc.Monitor()
 
@@ -173,15 +174,32 @@ def upgrade_message2( version_installed, version_available, version_stable, oldv
         log("Already notified one time for upgrading.")
 
 
+def abortRequested():
+    if KODI_VERSION_MAJOR > 13:
+        return monitor.abortRequested()
+    else:
+        return xbmc.abortRequested
+
+
+def waitForAbort(seconds):
+    if KODI_VERSION_MAJOR > 13:
+        return monitor.waitForAbort(seconds)
+    else:
+        for _ in range(0, seconds*1000/200):
+            if xbmc.abortRequested:
+                return True
+            xbmc.sleep(200)
+
+
 def wait_for_end_of_video():
     # Don't show notify while watching a video
-    while xbmc.Player().isPlayingVideo() and not monitor.abortRequested():
-        if monitor.waitForAbort(1):
+    while xbmc.Player().isPlayingVideo() and not abortRequested():
+        if waitForAbort(1):
             # Abort was requested while waiting. We should exit
             break
     i = 0
-    while i < 10 and not monitor.abortRequested():
-        if monitor.waitForAbort(1):
+    while i < 10 and not abortRequested():
+        if waitForAbort(1):
             # Abort was requested while waiting. We should exit
             break
         i += 1

--- a/service.py
+++ b/service.py
@@ -21,7 +21,7 @@ import platform
 import xbmc
 import xbmcgui
 import lib.common
-from lib.common import log, dialog_yesno, localise
+from lib.common import log, dialog_yesno, localise, waitForAbort
 from lib.common import upgrade_message as _upgrademessage
 from lib.common import upgrade_message2 as _upgrademessage2
 
@@ -39,7 +39,7 @@ class Main:
         linux = False
         packages = []
 
-        if monitor.waitForAbort(5):
+        if waitForAbort(5):
             sys.exit(0)
 
         if xbmc.getCondVisibility('System.Platform.Linux') and ADDON.getSetting("upgrade_apt") == 'true':


### PR DESCRIPTION
While testing one addon in Gotham I found the service is returning a script error:

```
10:29:05 T:2967576576   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.AttributeError'>
                                            Error Contents: 'xbmc.Monitor' object has no attribute 'abortRequested'
                                            Traceback (most recent call last):
                                              File "/Users/me/Library/Application Support/XBMC/addons/service.xbmc.versioncheck/service.py", line 104, in <module>
                                                Main()
                                              File "/Users/me/Library/Application Support/XBMC/addons/service.xbmc.versioncheck/service.py", line 45, in __init__
                                                _upgrademessage2( version_installed, version_available, version_stable, oldversion, False)
                                              File "/Users/me/Library/Application Support/XBMC/addons/service.xbmc.versioncheck/lib/common.py", line 108, in upgrade_message2
                                                wait_for_end_of_video()
                                              File "/Users/me/Library/Application Support/XBMC/addons/service.xbmc.versioncheck/lib/common.py", line 172, in wait_for_end_of_video
                                                while i < 10 and not monitor.abortRequested():
                                            AttributeError: 'xbmc.Monitor' object has no attribute 'abortRequested'
                                            -->End of Python script error report<--
10:29:05 T:2962178048  NOTICE: Thread BackgroundLoader start, auto delete: false
```

This PR adds a compatibility layer to only use such functions for Kodi versions higher than 13 (gotham). The alternative is used in lower versions.
It also updates the README adding "Kodi" where justified.