### PR TITLE
add one time notice 'Kodi Goes Python 3'

### DIFF
--- a/resources/k19_py3_notice.txt
+++ b/resources/k19_py3_notice.txt
@@ -1,0 +1,13 @@
+[UPPERCASE][B]Kodi Goes Python 3[/B][/UPPERCASE]
+November ..., 2019
+[I]For more information visit https://kodi.tv[/I]
+
+Nearly 2 years ago we announced that Kodi was migrating to using Python 3 interpreter for its many addons https://kodi.tv/article/attention-addon-developers-migration-python-3 and this explained why we were doing it and what would change. Since then we have been encouraging all addon developers to work towards that goal. As Python 2 is imminently reaching end of life 1st January 2020 we have needed to push this forwards, so have just taken the next big step: the nightly builds for Kodi Matrix are now based on using the Python 3 interpreter for running all Python-based addons
+
+This means that not only can addon developers test their work using the most recent Kodi build, but that early bird users of v19 also are able to use them. However this migration is very much a breaking change for us, and there is a lot of work that needs to be done to get things fully functional again. This also needs to be done quickly, as we need to be done before the end of life of Python 2 happens.
+
+The support of the wider community in this phase will be very welcome. For early users of Kodi v19 via the nightly builds the obvious issue is that a large number of addons are non-functional. Problems with specific addons can best be reported on the forum thread for that addon - read up if the author is already aware before posting. But the developers of some older addons are no longer active, so those with Python skills and an interest in Kodi are encouraged to get involved with updating some of the now otherwise unmaintained addons and scripts.
+
+There are also issues that need core developer knowledge to fix. Since moving to Python 3 there are some difficulties on all the Windows platforms in particular. The version of Kodi for UWP (Xbox) does not compile at all, and needs someone to champion it. There are also issues with certain libraries e.g. Pillow, PyCryptodome, cTypes etc., being missing or incompatible versions so those addons that depend on them don't run and can't be tested on Windows. There is also a conflict with having Python standalone installed and building Kodi on same Windows machine.
+
+Things will be a little raw at the edges until we can get these things fixed, so bare with us and if you have skills and can step up and contribute then please do.

--- a/resources/lib/version_check/service.py
+++ b/resources/lib/version_check/service.py
@@ -13,6 +13,7 @@
 
 """
 
+import os
 import sys
 
 import xbmc  # pylint: disable=import-error
@@ -20,6 +21,7 @@ import xbmcgui  # pylint: disable=import-error
 
 from .common import ADDON
 from .common import ADDON_NAME
+from .common import ADDON_PATH
 from .common import ADDON_VERSION
 from .common import dialog_yes_no
 from .common import localise
@@ -152,3 +154,15 @@ def run():
             old_version, version_installed, version_available, version_stable = _version_check()
             if old_version:
                 upgrade_message2(version_installed, version_available, version_stable, old_version)
+
+            # give early adopters a one time notice of the change to Python 3,
+            # if using Kodi 19 non-stable w/ python 3
+            if (version_installed['major'] == 19 and
+                    version_installed['tag'] in ['alpha', 'beta', 'releasecandidate'] and
+                    sys.version_info[0] >= 3 and
+                    ADDON.getSetting('python_3_notice') != 'true'):
+                script_path = os.path.join(ADDON_PATH, 'resources', 'lib',
+                                           'version_check', 'viewer.py')
+                xbmc.executebuiltin('RunScript(%s,%s,%s)' %
+                                    (script_path, 'Kodi Goes Python 3', 'k19_py3_notice.txt'))
+                ADDON.setSetting('python_3_notice', 'true')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,5 +4,6 @@
         <setting label="32021" type="bool" id="versioncheck_enable" default="true"/>
         <setting label="32023" type="bool" id="upgrade_system" default="false"/>
         <setting label="32024" type="bool" id="upgrade_apt" default="false"/>
+        <setting type="bool" id="python_3_notice" default="false" visible="false"/>
     </category>
 </settings>


### PR DESCRIPTION
<!-- - user is shown the Kodi Goes Python 3 blog post -->
<!-- - notification is shown if user is using Kodi 19 alpha/beta/rc w/ and python 3 -->
<!-- - only notify the user once -->

<!-- ![python-3-notice](https://user-images.githubusercontent.com/17665050/68215536-6a56a880-ffad-11e9-8c0f-11ea6b18bac2.png) -->
