### PR TITLE
Use xbmcvfs for translatePath for matrix

### DIFF
--- a/resources/lib/version_check/common.py
+++ b/resources/lib/version_check/common.py
@@ -17,13 +17,14 @@ import sys
 import xbmc  # pylint: disable=import-error
 import xbmcaddon  # pylint: disable=import-error
 import xbmcgui  # pylint: disable=import-error
+import xbmcvfs  # pylint: disable=import-error
 
 ADDON = xbmcaddon.Addon('service.xbmc.versioncheck')
 ADDON_VERSION = ADDON.getAddonInfo('version')
 ADDON_NAME = ADDON.getAddonInfo('name')
 if sys.version_info[0] >= 3:
     ADDON_PATH = ADDON.getAddonInfo('path')
-    ADDON_PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
+    ADDON_PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 else:
     ADDON_PATH = ADDON.getAddonInfo('path').decode('utf-8')
     ADDON_PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile')).decode('utf-8')


### PR DESCRIPTION
Silences the warning we see in logs when running this on matrix. We might consider to sync github.com/xbmc/xbmc at some point with the most up to date version of this addon.