### PR TITLE
Fix UnicodeDecodeError in distro.py

### DIFF
--- a/resources/lib/version_check/distro/distro.py
+++ b/resources/lib/version_check/distro/distro.py
@@ -28,6 +28,7 @@ is needed. See `Python issue 1322 <https://bugs.python.org/issue1322>`_ for
 more information.
 """
 
+import io
 import os
 import re
 import sys
@@ -1147,7 +1148,7 @@ class LinuxDistribution(object):
             A dictionary containing all information items.
         """
         try:
-            with open(filepath) as fp:
+            with io.open(filepath, 'r', encoding='utf-8') as fp:
                 # Only parse the first line. For instance, on SLES there
                 # are multiple lines. We don't want them...
                 return self._parse_distro_release_content(fp.readline())


### PR DESCRIPTION
`distro.py` throws `UnicodeDecodeError` if any file in `/etc` contains a non-ascii character, e.g.:
```
2021-10-27 23:19:39.327 T:1781498   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'UnicodeDecodeError'>
                                                   Error Contents: 'ascii' codec can't decode byte 0xe7 in position 50: ordinal not in range(128)
                                                   Traceback (most recent call last):
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/runner.py", line 14, in <module>
                                                       from version_check import service  # pylint: disable=import-error
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/service.py", line 44, in <module>
                                                       DISTRIBUTION = distro.linux_distribution(full_distribution_name=False)[0].lower()
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 122, in linux_distribution
                                                       return _distro.linux_distribution(full_distribution_name)
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 677, in linux_distribution
                                                       self.version(),
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 738, in version
                                                       self.distro_release_attr('version_id'),
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 908, in distro_release_attr
                                                       return self._distro_release_info.get(attribute, '')
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 552, in __get__
                                                       ret = obj.__dict__[self._fname] = self._f(obj)
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 1128, in _distro_release_info
                                                       distro_info = self._parse_distro_release_file(filepath)
                                                     File "/home/milan/.kodi/addons/service.xbmc.versioncheck/resources/lib/version_check/distro/distro.py", line 1153, in _parse_distro_release_file
                                                       return self._parse_distro_release_content(fp.readline())
                                                     File "/usr/lib/python3.9/encodings/ascii.py", line 26, in decode
                                                       return codecs.ascii_decode(input, self.errors)[0]
                                                   UnicodeDecodeError: 'ascii' codec can't decode byte 0xe7 in position 50: ordinal not in range(128)
                                                   -->End of Python script error report<--
```
With this PR, we open all files as `utf-8`, as suggested on the [wiki](https://kodi.wiki/view/General_information_about_migration_to_Python_3#Know_the_libraries_you_are_using)

### Additional info

In my case the offending file was `/etc/deepin-version`
```
$ cat /etc/deepin-version 
[Release]
Version=20.2.2
Type=Desktop
Type[zh_CN]=社区版
Edition=Y2020E0001
Copyright=Y2020CR001
[Addition]
Milestone=
Buildid=build1
```
```
$ hexdump -C /etc/deepin-version
00000000  5b 52 65 6c 65 61 73 65  5d 0a 56 65 72 73 69 6f  |[Release].Versio|
00000010  6e 3d 32 30 2e 32 2e 32  0a 54 79 70 65 3d 44 65  |n=20.2.2.Type=De|
00000020  73 6b 74 6f 70 0a 54 79  70 65 5b 7a 68 5f 43 4e  |sktop.Type[zh_CN|
00000030  5d 3d e7 a4 be e5 8c ba  e7 89 88 0a 45 64 69 74  |]=..........Edit|
00000040  69 6f 6e 3d 59 32 30 32  30 45 30 30 30 31 0a 43  |ion=Y2020E0001.C|
00000050  6f 70 79 72 69 67 68 74  3d 59 32 30 32 30 43 52  |opyright=Y2020CR|
00000060  30 30 31 0a 5b 41 64 64  69 74 69 6f 6e 5d 0a 4d  |001.[Addition].M|
00000070  69 6c 65 73 74 6f 6e 65  3d 0a 42 75 69 6c 64 69  |ilestone=.Buildi|
00000080  64 3d 62 75 69 6c 64 31  0a                       |d=build1.|
00000089

```