### PR TITLE
Catch subprocess error on lsb_release subprocess

### DIFF
--- a/resources/lib/version_check/distro/distro.py
+++ b/resources/lib/version_check/distro/distro.py
@@ -1011,7 +1011,7 @@ class LinuxDistribution(object):
             try:
                 cmd = ('lsb_release', '-a')
                 stdout = subprocess.check_output(cmd, stderr=devnull)
-            except OSError:  # Command not found
+            except (OSError, subprocess.CalledProcessError):  # Command not found
                 return {}
         content = stdout.decode(sys.getfilesystemencoding()).splitlines()
         return self._parse_lsb_release_content(content)


### PR DESCRIPTION
Also done upstream (we keep the distro module builtin because we still support python2 on this addon): https://github.com/python-distro/distro/blob/master/src/distro/distro.py#L1163


Closes https://github.com/XBMC-Addons/service.xbmc.versioncheck/issues/146