### PR TITLE
Fix apt shell handler raising exception and skipping update.

### DIFF
--- a/resources/lib/version_check/common.py
+++ b/resources/lib/version_check/common.py
@@ -172,12 +172,15 @@ def upgrade_message(msg):
     wait_for_end_of_video()
 
     if ADDON.getSetting('lastnotified_version') < ADDON_VERSION:
-        xbmcgui.Dialog().ok(
+        answer = xbmcgui.Dialog().ok(
             ADDON_NAME,
             '[CR]'.join([localise(msg), localise(32001), localise(32002)])
         )
     else:
+        answer = False
         log('Already notified one time for upgrading.')
+
+    return answer
 
 
 def upgrade_message2(version_installed, version_available, version_stable, old_version):

--- a/resources/lib/version_check/shell_handler_apt.py
+++ b/resources/lib/version_check/shell_handler_apt.py
@@ -53,7 +53,7 @@ class ShellHandlerApt(Handler):
             return False, False
 
         try:
-            result = check_output([_cmd], shell=True).split('\n')
+            result = check_output([_cmd], shell=True).decode('utf-8').split('\n')
         except Exception as error:  # pylint: disable=broad-except
             log('ShellHandlerApt: exception while executing shell command %s: %s' % (_cmd, error))
             return False, False


### PR DESCRIPTION
Using the shell apt handler, the addon exits before attempting any update or upgrade due to an exception raised by the `ShellHandlerApt` `_check_versions` method. 
```
debug <general>: Version Check: ShellHandlerApt: exception while executing shell command apt-cache policy kodi: a bytes-like object is required, not 'str'
debug <general>: Version Check: No installed package found, exiting
debug <general>: CPythonInvoker(4, /home/kodi/.kodi/addons/service.xbmc.versioncheck/resources/lib/runner.py): script aborted
debug <general>: onExecutionDone(4, /home/kodi/.kodi/addons/service.xbmc.versioncheck/resources/lib/runner.py)
```
I suggest then to decode the command output as UTF-8 text to allow splitting and parsing in d47f92a5a26772429a58f9eba003e134daa154a9.

Additionally, when clicking OK when the `upgrade_message` is displayed, no update or upgrade is made because the function does not return the [expected boolean](https://github.com/XBMC-Addons/service.xbmc.versioncheck/blob/210dbb134d26b4f7a58fc46afefdb0197965d252/resources/lib/version_check/service.py#L99C23-L99C23). This is why I modified the `upgrade_message` function in 801d85784ee05e94c8cfe2090bf09de426ad4ab1 to return a boolean depending on the user choice.